### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ python train.py                             # trains both models, prints log‑l
 uvicorn api.main:app --reload               # serves the endpoints
 # open a second terminal
 streamlit run app.py                        # launches the dashboard
+```


### PR DESCRIPTION
## Summary
- close the quick-start shell code block in the README

## Testing
- `python -m compileall -q src`
- `python -m py_compile $(git ls-files '*.py')`
