### PR TITLE
Fix docs for ingest script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Our memory‑3 model consistently beats the classic memory‑0 EPV by **≥ 4 
 # 1. open the repo in Codespaces (browser)
 # 2. run:
 python -m pip install -r requirements.txt   # should be no‑op in Codespace
-python ingest.py --game 0022400001          # pulls a Bucks‑vs‑Celtics demo game
+python src/ingest.py 0022400001          # pulls a Bucks‑vs‑Celtics demo game
 python train.py                             # trains both models, prints log‑loss
-uvicorn api.main:app --reload               # serves the endpoints
 # open a second terminal
 streamlit run app.py                        # launches the dashboard


### PR DESCRIPTION
## Summary
- fix path for ingest script in README
- remove API step that referenced missing module

## Testing
- `python -m py_compile $(git ls-files '*.py')`
